### PR TITLE
routing: bug#41: fix routing table 1.5

### DIFF
--- a/main.py
+++ b/main.py
@@ -993,8 +993,14 @@ async def api_routing_table():
                 
                 # Format the data for better readability
                 formatted_routes = []
+
+                # Check if the data has a default key; indicates using 1.5
+                if routes_data.get("default"):
+                    route_path = routes_data.get("default")
+                else:
+                    route_path = routes_data                
                 
-                for prefix, routes_list in routes_data.items():
+                for prefix, routes_list in route_path.items():
                     for route in routes_list:
                         # Extract the key information for each route
                         formatted_route = {


### PR DESCRIPTION
The format of routes pulled from 1.4 started with just the route. In 1.4, it started with the VRF name. A simple check was added to validate which format is in use.